### PR TITLE
Add init flag: Create default configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ go get -tool github.com/cc-jj/pulse@latest
 Run it from any Go project directory
 
 ```
-# run using the default config
-go tool pulse
-
-# run using a custom config
-go tool pulse -c=/path/to/pulse.json
+# initialize pulse with a default config in the current working directory
+go tool -init
 
 # print the verison
 go tool pulse -v
+
+# run specifying the config path
+go tool pulse -c=/path/to/pulse.json
+
+# run using the default config path (./pulse.json)
+go tool pulse
 ```
 
 ## Configuration

--- a/main.go
+++ b/main.go
@@ -47,11 +47,27 @@ var (
 
 func main() {
 	versionFlag := flag.Bool("v", false, "Print version information and exit")
+	initFlag := flag.Bool("init", false, "Initialize a new pulse.json configuration file")
 	configFlag := flag.String("c", DefaultConfigPath, "Specify the configuration file path")
 	flag.Parse()
 
 	if *versionFlag {
 		fmt.Printf("Go Pulse v%s\n", Version)
+		return
+	}
+
+	if *initFlag {
+		data, err := json.MarshalIndent(config, "", "  ")
+		if err != nil {
+			fmt.Printf("Error creating default config: %s\n", err)
+			return
+		}
+		path := "pulse.json"
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			fmt.Printf("Error writing config file: %s\n", err)
+			return
+		}
+		fmt.Printf("Configuration file created at %s\n", path)
 		return
 	}
 


### PR DESCRIPTION
Add a new command flag `-init`. When passed, write the default configuration to the current working directory and exit:

```command line
>> go tool pulse -init
Configuration file created at pulse.json
```