### PR TITLE
Fix README init usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run it from any Go project directory
 
 ```
 # initialize pulse with a default config in the current working directory
-go tool -init
+go tool pulse -init
 
 # print the verison
 go tool pulse -v


### PR DESCRIPTION
This fixes a typo introduced in https://github.com/cc-jj/pulse/pull/2